### PR TITLE
added appName to aws services payload

### DIFF
--- a/src/controllers/aws.controllers.js
+++ b/src/controllers/aws.controllers.js
@@ -5,8 +5,8 @@ const { ElasticLoadBalancingV2, DescribeLoadBalancersCommand } = require("@aws-s
 
 const { IAMClient, GetUserCommand } = require("@aws-sdk/client-iam");
 
-let app = "0609"
-let env = "0609-env";
+let app = "empty"
+let env = "empty";
 
 
 async function applications(req, res) {
@@ -137,7 +137,7 @@ async function addEnvironmentToBucket(req, res) {
   const services = {
     Bucket: "cascade-" + req.body.app.toLowerCase() + "-" + id,
     Key: `${env}/services.json`,
-    Body: JSON.stringify({ envName: env, region: req.body.region, credentials: { accessKeyId: req.body.accessKey, secretAccessKey: req.body.secretKey }, containers: [], s3Arn: `arn:aws:s3:::cascade-${app}-${id}`})
+    Body: JSON.stringify({ appName: app, envName: env, region: req.body.region, credentials: { accessKeyId: req.body.accessKey, secretAccessKey: req.body.secretKey }, containers: [], s3Arn: `arn:aws:s3:::cascade-${app}-${id}`})
   }
 
   const client = new S3Client();
@@ -172,6 +172,8 @@ async function addServiceToBucket(req, res) {
   const userResponse = await user.send(getUser);
 
   const id = userResponse.User.Arn.match(/\d+/)[0]
+
+  console.log(req.body, "request body from add service to bucket")
 
   const s3Client = new S3Client();
   const bucketParams = {

--- a/src/controllers/terraform.controller.js
+++ b/src/controllers/terraform.controller.js
@@ -3,8 +3,8 @@ const { IAMClient, GetUserCommand } = require("@aws-sdk/client-iam");
 const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 const fs = require('fs');
 
-const app = '0609'
-const env = '0609-env'
+const app = 'empty'
+const env = 'empty'
 
 // const client = { stream: null } // res now accessible from /stream
 


### PR DESCRIPTION
Co-authored-by: Anne Tiotuico <amtiotuico@gmail.com>
Co-authored-by: Natalie Thompson <Natalie.A.Thompson@outlook.com>
Co-authored-by: Rona Hsu <ronahsu@gmail.com>

- not ready to commit
- added `appName` to the services payload, which was needed for the add container modal to access the s3
  - might be worth it to store app and env name (from the welcome page) in our db that can be easily fetched